### PR TITLE
Fix two small typos in gt4py branch

### DIFF
--- a/src/cloudsc_gt4py/src/cloudsc4py/physics/_stencils/cloudsc.py
+++ b/src/cloudsc_gt4py/src/cloudsc4py/physics/_stencils/cloudsc.py
@@ -1383,7 +1383,7 @@ def cloudsc(
                 lo1 = covpclr > EPSEC and qs > EPSEC and qe < rh * qsice
                 if lo1:
                     # calculate local precipitation (kg/kg)
-                    preclr = qsfg / tmp_covptot[0, 0]
+                    preclr = qs / tmp_covptot[0, 0]
                     vpice = f_foeeice(t) * RV / RD
 
                     # particle size distribution

--- a/src/cloudsc_gt4py/src/cloudsc4py/physics/_stencils/cuadjtq.py
+++ b/src/cloudsc_gt4py/src/cloudsc4py/physics/_stencils/cuadjtq.py
@@ -20,7 +20,7 @@ def f_cuadjtq_5(qp, qsmix, t):
     return qsmix, t
 
 
-@ported_function(from_file="cloudsc_fortran/cloudsc2.F90", from_line=1297, to_line=1314)
+@ported_function(from_file="cloudsc_fortran/cloudsc.F90", from_line=1297, to_line=1314)
 @function_collection("f_cuadjtq")
 @gtscript.function
 def f_cuadjtq(ap, qsmix, t):


### PR DESCRIPTION
Changes `qsfg` variable back to `qs` as in original fortran code.
Changes filename in `@ported_function` from `cloudsc2.f90` back to `cloudsc.f90`.